### PR TITLE
:sparkles: GPS機能追加

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/material": "^5.14.9",
+        "@react-google-maps/api": "^2.19.2",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3057,6 +3058,23 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.3.tgz",
       "integrity": "sha512-uvnFKtPgzLnpzzTRfhDlvXX0kLYi9lDRQbcDmT8iXl71Rx+uwSuaUIQl3DNC7w5OweAQ7XQMDObML+KaYDQfng=="
     },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.2.tgz",
+      "integrity": "sha512-psGw5u0QM6humao48Hn4lrChOM2/rA43ZCm3tKK9qQsEj1/VzqkCqnvGfEOshDbBQflydfaRovbKwZMF4AyqbA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "node_modules/@googlemaps/markerclusterer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.3.2.tgz",
+      "integrity": "sha512-zb9OQP8XscZp2Npt1uQUYnGKu1miuq4DPP28JyDuFd6HV17HCEcjV9MtBi4muG/iVRXXvuHW9bRCnHbao9ITfw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "supercluster": "^8.0.1"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.8.21",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.21.tgz",
@@ -4277,6 +4295,33 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "node_modules/@react-google-maps/api": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.19.2.tgz",
+      "integrity": "sha512-Vt57XWzCKfsUjKOmFUl2erVVfOePkPK5OigF/f+q7UuV/Nm9KDDy1PMFBx+wNahEqOd6a32BxfsykEhBnbU9wQ==",
+      "dependencies": {
+        "@googlemaps/js-api-loader": "1.16.2",
+        "@googlemaps/markerclusterer": "2.3.2",
+        "@react-google-maps/infobox": "2.19.2",
+        "@react-google-maps/marker-clusterer": "2.19.2",
+        "@types/google.maps": "3.53.5",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
+      }
+    },
+    "node_modules/@react-google-maps/infobox": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/infobox/-/infobox-2.19.2.tgz",
+      "integrity": "sha512-6wvBqeJsQ/eFSvoxg+9VoncQvNoVCdmxzxRpLvmjPD+nNC6mHM0vJH1xSqaKijkMrfLJT0nfkTGpovrF896jwg=="
+    },
+    "node_modules/@react-google-maps/marker-clusterer": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.19.2.tgz",
+      "integrity": "sha512-x9ibmsP0ZVqzyCo1Pitbw+4b6iEXRw/r1TCy3vOUR3eKrzWLnHYZMR325BkZW2r8fnuWE/V3Fp4QZOP9qYORCw=="
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
@@ -5033,6 +5078,11 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.53.5",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.53.5.tgz",
+      "integrity": "sha512-HoRq4Te8J6krH7hj+TfdYepqegoKZCj3kkaK5gf+ySFSHLvyqYkDvkrtbcVJXQ6QBphQ0h1TF7p4J6sOh4r/zg=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
@@ -10195,6 +10245,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
@@ -12885,6 +12943,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA=="
     },
     "node_modules/keyv": {
       "version": "4.5.3",
@@ -17130,6 +17193,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "dependencies": {
+        "kdbush": "^4.0.2"
       }
     },
     "node_modules/supports-color": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^5.14.9",
+    "@react-google-maps/api": "^2.19.2",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/frontend/src/features/Chat/OutputSpots.tsx
+++ b/frontend/src/features/Chat/OutputSpots.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
-  Grid
+  Grid,
+  AppBar,
+  Typography,
+  Tabs,
+  Tab
 } from "@mui/material";
 import {
   MyCard,
@@ -10,6 +14,46 @@ import {
 import TextWithoutSpots from './TextWithoutSpots';
 import SpotCard from './SpotCard';
 import { useAppState } from '../../pages/Chat/ChatProvider';
+import Map from '../Map/Map';
+
+/**
+ * タブのラベルとコンテンツの関連付け
+ * @param {number} index タブのインデックス 
+ * @returns {object} タブのラベルとコンテンツの関連付け
+ */
+const a11yProps = (index: number) => ({
+  id: `simple-tab-${index}`,
+  "aria-controls": `simple-tabpanel-${index}`,
+});
+
+/**
+ * タブコンポーネント
+ * @param {object} children 子要素
+ * @param {number} index タブのindex
+ * @param {number} value アクティブなタブのindex
+ * @param {object} other その他の引数
+ * @returns {TSX.Element} タブコンポーネント
+ */
+const TabPanel: React.FC<{
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}> = ({ children, value, index, ...other }) => (
+  <div
+    role="tabpanel"
+    hidden={value !== index}
+    id={`simple-tabpanel-${index}`}
+    aria-labelledby={`simple-tab-${index}`}
+    {...other}
+  >
+    {value === index && (
+      <Typography component="div" p={2}>
+        {children}
+      </Typography>
+    )}
+  </div>
+);
+
 
 /**
  * 観光地出力コンポーネント
@@ -19,19 +63,42 @@ import { useAppState } from '../../pages/Chat/ChatProvider';
  */
 const OutputSpots: React.FC = () => {
   const { state } = useAppState();
+  const [value, setValue] = useState(0);
   const { spots, loadingFlg, startChatFlg } = state;
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue);
+  };
   return (
     <MyDivContainer>
       <Grid container direction="column" alignItems="center">
         {startChatFlg && !loadingFlg &&
           <MyCard>
             <MyCardHeader title="Recommended spots for you" /><br />
-            {spots.length === 0 ? (
-              <TextWithoutSpots />
-            ) : (spots.map((spot) => (
-              <SpotCard key={spot.id} spot={spot} />
-            ))
-            )}
+            <AppBar position="static" color="default">
+              <Tabs
+                value={value}
+                onChange={handleChange}
+                aria-label="simple tabs example"
+                indicatorColor="primary"
+                textColor="primary"
+              >
+                <Tab label="LIST" {...a11yProps(0)} />
+                <Tab label="MAP" {...a11yProps(1)} />
+              </Tabs>
+            </AppBar>
+            <TabPanel value={value} index={0}>
+              {spots.length === 0 ? (
+                <TextWithoutSpots />
+              ) : (
+                spots.map((spot) => (
+                  <SpotCard key={spot.id} spot={spot} />
+                ))
+              )
+              }
+            </TabPanel>
+            <TabPanel value={value} index={1}>
+              <Map spots={spots} />
+            </TabPanel>
           </MyCard>
         }
       </Grid>

--- a/frontend/src/features/Chat/SpotCard.tsx
+++ b/frontend/src/features/Chat/SpotCard.tsx
@@ -11,7 +11,7 @@ import {
     keywordButtonStyle,
 } from '../../styles/styles';
 import { typeSpots } from '../../functions/FirestoreFunction';
-
+import MapLinkButton from '../Map/MapButton';
 interface SpotCardProps {
     spot: typeSpots
 }
@@ -27,6 +27,14 @@ const SpotCard: React.FC<SpotCardProps> = ({ spot }) => {
                             {spot.name}
                         </a>
                     </strong>
+                    <MapLinkButton
+                        location={{
+                            name: spot.name,
+                            lat: spot.geopoint.latitude,
+                            lng: spot.geopoint.longitude,
+                        }}
+                        label="MAP"
+                    />
                 </Typography>
                 <div>
                     エリア：

--- a/frontend/src/features/Map/Map.tsx
+++ b/frontend/src/features/Map/Map.tsx
@@ -1,0 +1,131 @@
+import React, { useState, useRef, useEffect } from "react";
+import { typeSpots } from "../../functions/FirestoreFunction";
+import { Card } from "@mui/material";
+import { GoogleMap, LoadScriptNext, MarkerF } from "@react-google-maps/api";
+
+// ChatMemoの引数の型定義
+interface MapProps {
+  spots: typeSpots[];
+}
+
+interface LocationState {
+  latitude: number | null;
+  longitude: number | null;
+  error: string | null;
+}
+
+/**
+ * 観光地のMAPを表示するコンポーネント
+ * @param {object} spots 観光地の情報
+ * @returns {TSX.Element}　観光地のMAPを表示
+ */
+const Map: React.FC<MapProps> = ({ spots }) => {
+  const mapRef = useRef<google.maps.Map>();
+  const [mapLoaded, setMapLoaded] = useState(false);
+  const [markersLoaded, setMarkersLoaded] = useState(0);
+  const [location, setLocation] = useState<LocationState>({
+    latitude: null,
+    longitude: null,
+    error: null,
+  });
+  const mapContanerStyle = {
+    width: "100%",
+    height: "400px",
+  };
+  const defaultCenter = { lat: 36.595377, lng: 136.625576 };
+  const mapApiKey = process.env.REACT_APP_GOOGLEMAP_APIKEY as string;
+  const handleMapLoad = (map: google.maps.Map) => {
+    mapRef.current = map;
+    setMapLoaded(true);
+  };
+  const handleMarkerLoad = () => {
+    setMarkersLoaded((prev) => prev + 1);
+  };
+  useEffect(() => {
+    if (
+      mapLoaded &&
+      markersLoaded === spots.length &&
+      mapRef.current &&
+      spots.length > 0
+    ) {
+      const bounds = new google.maps.LatLngBounds();
+      spots.forEach((spot) => {
+        bounds.extend(
+          new google.maps.LatLng(
+            spot.geopoint.latitude,
+            spot.geopoint.longitude
+          )
+        );
+      });
+      if (location.latitude !== null && location.longitude !== null) {
+        bounds.extend(
+          new google.maps.LatLng(location.latitude, location.longitude)
+        );
+      }
+      mapRef.current.fitBounds(bounds);
+    }
+  }, [spots, mapLoaded, markersLoaded]);
+
+  useEffect(() => {
+    if (!navigator.geolocation) {
+      setLocation((prevState) => ({
+        ...prevState,
+        error:
+          "あなたが使用しているブラウザはGeolocationをサポートしていません。",
+      }));
+    } else {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          setLocation({
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+            error: null,
+          });
+        },
+        () => {
+          setLocation((prevState) => ({
+            ...prevState,
+            error: "あなたの位置情報を取得することができません。",
+          }));
+        }
+      );
+    }
+  }, []);
+  return (
+    <div>
+      <Card style={{ border: "1px solid #ccc" }}>
+        <LoadScriptNext googleMapsApiKey={mapApiKey}>
+          <GoogleMap
+            mapContainerStyle={mapContanerStyle}
+            onLoad={handleMapLoad}
+            center={defaultCenter}
+            zoom={6}
+          >
+            {spots.map((spot) => (
+              <MarkerF
+                key={spot.id}
+                position={{
+                  lat: spot.geopoint.latitude,
+                  lng: spot.geopoint.longitude,
+                }}
+                onLoad={handleMarkerLoad}
+                label={spot.name}
+              />
+            ))}
+            {location.latitude !== null && location.longitude !== null && (
+              <MarkerF
+                position={{
+                  lat: location.latitude,
+                  lng: location.longitude,
+                }}
+                label="現在地"
+              />
+            )}
+          </GoogleMap>
+        </LoadScriptNext>
+      </Card>
+    </div>
+  );
+};
+
+export default Map;

--- a/frontend/src/features/Map/MapButton.tsx
+++ b/frontend/src/features/Map/MapButton.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Button } from "@mui/material";
+import { MapButton } from "../../styles/styles";
+
+interface Location {
+  name: string;
+  lat: number;
+  lng: number;
+}
+
+interface MapLinkButtonProps {
+  location: Location;
+  label: string;
+}
+
+
+/**
+ * マップリンクボタンコンポーネント
+ * @param {object} location 観光地の情報
+ * @param {string} label ボタンのラベル
+ * @returns {TSX.Element}マップリンクボタン
+ */
+const MapLinkButton: React.FC<MapLinkButtonProps> = ({ location, label }) => {
+  const handleButtonClick = () => {
+    const encodedName = encodeURIComponent(location.name);
+    const googleMapsUrl = `https://www.google.com/maps/dir/?api=1&origin=Current+Location&destination=${encodedName}`;
+    window.open(googleMapsUrl, "_blank");
+  };
+
+  return (
+    <Button onClick={handleButtonClick} style={MapButton}>
+      {label}
+    </Button>
+  );
+};
+
+export default MapLinkButton;

--- a/frontend/src/functions/FirestoreFunction.ts
+++ b/frontend/src/functions/FirestoreFunction.ts
@@ -23,6 +23,7 @@ export interface typeSpots {
     area: string;
     category: string;
     keyword: string;
+    geopoint: { latitude: number; longitude: number };
 }
 
 /**
@@ -81,6 +82,7 @@ export const fetchSpots = async (keywords: string[]) => {
                         area: "",
                         category: "",
                         keyword: "",
+                        geopoint: docData.geopoint,
                     });
                 }
             });

--- a/frontend/src/styles/styles.ts
+++ b/frontend/src/styles/styles.ts
@@ -75,3 +75,10 @@ export const pStyle: React.CSSProperties = {
     whiteSpace: 'pre-wrap' as 'pre-wrap', // 'pre-wrap'型として指定
     wordWrap: 'break-word' as 'break-word', // 'break-word'型として指定
 };
+
+export const MapButton = {
+    color: "#fff",
+    backgroundColor: "#1F73E8",
+    borderRadius: "4px",
+    marginLeft: "14px",
+};


### PR DESCRIPTION
抽出されたspotのリストから位置情報(緯度経度)を取得し、
Google MAPにてマーカー表示。
spotのリストとMAPはタブによって表示の切り替えを行う。
リストにMAPボタンを追加し、クリックすることで、
Google MAPが起動され、現在地から道案内を提示する。